### PR TITLE
feat: add past activities endpoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -227,6 +227,31 @@ Required fields (in JSON format):
 
   _All fields are required._
 
+Path to get past activities:
+Method: get,
+Path: `/past-activities`
+Required fields: none
+Example response:
+
+```
+{
+  "message": "Actividades pasadas obtenidas",
+  "data": [
+    {
+      "id": "abc123",
+      "summary": "Taller",
+      "description": "Sesión de apoyo",
+      "start": "2024-09-01T10:00:00.000Z",
+      "end": "2024-09-01T12:00:00.000Z",
+      "location": "Centro",
+      "access": "libre",
+      "status": "confirmed",
+      "image": "https://example.com/image.jpg"
+    }
+  ]
+}
+```
+
 **contact**
 Path to save contact data:
 Method: post,

--- a/src/controllers/freeActivities/getFilteredActivities.js
+++ b/src/controllers/freeActivities/getFilteredActivities.js
@@ -29,6 +29,8 @@ const getFilteredActivities = async (req, res, next) => {
             end: parseCustomDateToISO(row[4]),
             location: row[5],
             access: row[6],
+            status: row[7],
+            image: row[8],
         }))
 
         // Filtrar las actividades según los parámetros
@@ -90,4 +92,41 @@ const getFilteredActivities = async (req, res, next) => {
     }
 }
 
+const getPastActivities = async (req, res, next) => {
+    try {
+        const sheetId = process.env.SPREADSHEET_ID
+        const response = await allSheetData(sheetId, 'Actividades')
+        const { rows } = response
+
+        const activities = rows.slice(1).map((row) => ({
+            id: row[0],
+            summary: row[1],
+            description: row[2],
+            start: parseCustomDateToISO(row[3]),
+            end: parseCustomDateToISO(row[4]),
+            location: row[5],
+            access: row[6],
+            status: row[7],
+            image: row[8],
+        }))
+
+        const now = Date.now()
+        const pastActivities = activities.filter(
+            (activity) => new Date(activity.end).getTime() < now
+        )
+
+        if (pastActivities.length === 0)
+            generateError('No hay actividades pasadas')
+
+        res.json({
+            message: 'Actividades pasadas obtenidas',
+            data: pastActivities,
+        })
+    } catch (error) {
+        console.log(error)
+        next(error)
+    }
+}
+
+export { getPastActivities }
 export default getFilteredActivities

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -18,7 +18,9 @@ import googleSignIn from './googleSignIn/googleSignIn.js'
 import checkSession from './googleSignIn/checkSession.js'
 import logout from './googleSignIn/logout.js'
 
-import getFilteredActivities from './freeActivities/getFilteredActivities.js'
+import getFilteredActivities, {
+  getPastActivities,
+} from './freeActivities/getFilteredActivities.js'
 import createActivity from './freeActivities/createActivity.js'
 
 import createFormController from './forms/createFormController.js'
@@ -72,6 +74,7 @@ export {
   checkSession,
   logout,
   getFilteredActivities,
+  getPastActivities,
   createFormController,
   saveFormResponses,
   getAllForms,

--- a/src/routes/activitiesRouter.js
+++ b/src/routes/activitiesRouter.js
@@ -1,5 +1,9 @@
 import express from 'express'
-import { createActivity, getFilteredActivities } from '../controllers/index.js'
+import {
+  createActivity,
+  getFilteredActivities,
+  getPastActivities,
+} from '../controllers/index.js'
 import { storage, limits, fileFilter } from '../utils/index.js'
 import multer from 'multer'
 
@@ -9,5 +13,6 @@ const upload = multer({ storage: storage, limits, fileFilter })
 //Ruta para actividades:
 router.post('/create-activity', upload.single('image'), createActivity)
 router.post('/get-filtered-activities', getFilteredActivities)
+router.get('/past-activities', getPastActivities)
 
 export default router


### PR DESCRIPTION
## Summary
- include image and status fields when listing activities
- add controller and route to retrieve past activities
- document new past activities endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bee08943908323a9473268ae1976a7